### PR TITLE
Display unresolved comments at the bottom

### DIFF
--- a/tracker.js
+++ b/tracker.js
@@ -6,6 +6,7 @@
 // Other file forwarders
 var Parse;
 var waitForKeyElements;
+var unresolvedComments = new Set();
 
 var findAllThreads = function () {
   var threads = [];
@@ -143,10 +144,12 @@ var updateMergeButton = function () {
         '      <span class="status-meta">' +
         '        See above for red unresolved comments' +
         '      </span>' +
+        '      <lu><li>' + Array.from(unresolvedComments).join('</li><li>') + "</li></lu>" +
         '  </div>'
       );
     }
   }
+  unresolvedComments.clear();
 };
 
 var annotateWithParseInfo = function (allThreads) {
@@ -211,6 +214,11 @@ var makeButton = function (elem, threadInfo) {
 
       updateThread(threadInfo);
     });
+
+    var content = $elem.find(actionSelector)[0].innerText.trim();
+    if (content != "") {
+      unresolvedComments.add(content);
+    }
   }
 };
 


### PR DESCRIPTION
Whenever an 'unresolved' button is built (makeButton), store the comment into a Set (I had cases where the same comment was added twice, thus in my own implementation I used a Set to prevent duplication. 

Then, with my limited knowledge of Javascript, to display the content: I convert the set into an array, in order to join the elements in a list.

For now, this only covers the Discussion tab. I'll wait for these 3-4 PR to go through and I'll submit the same for the Files tab.