### PR TITLE
Add threads under 'files' tab

### DIFF
--- a/tracker.js
+++ b/tracker.js
@@ -32,6 +32,14 @@ var findAllThreads = function () {
     }
   });
 
+  $('#files .review-comment').each(function () {
+    threads.push({
+      id: this.id,
+      comments: $(this),
+      lastCommentId: this.id,
+    });
+  });
+
   return threads;
 };
 


### PR DESCRIPTION
Loads the threads from the files tab. I did not include any condition on the id (like you did for the `#discussion_bucket` => `this.id.match(/^issuecomment/)`.

From my tests, all comments under the file tabs had ids with this format: `r[0-9]+`.