### PR TITLE
Use chrome style options page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,5 +16,9 @@
     "css": ["main.css"]
   }],
 
-  "options_page": "options.html"
+  "options_page": "options.html",
+  "options_ui": {
+    "chrome_style": true,
+    "page": "options.html"
+  }
 }


### PR DESCRIPTION
I don't know if you are aware and/or if you want this.

The additional property in the manifest tells chrome to display the options page with chrome's style. See screenshot:

<img width="487" alt="screen shot 2017-10-09 at 3 56 44 pm" src="https://user-images.githubusercontent.com/7472034/31356032-80abc950-ad0a-11e7-8199-15104fea51a0.png">
